### PR TITLE
Specify Heroku App Name in Travis Config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ env:
     secure:
 deploy:
   provider: heroku
+  app: wine-service-sinatra
   on:
     repo: WeatherVine/wine_service
     branch: main


### PR DESCRIPTION
### What Changed?
- Add heroku app name to travis config
  - We ended up removing the line in one of our previous attempts at getting travis to deploy correctly...
  - So, whether or not this fixes the deploy issue it _does_ need to be updated.
